### PR TITLE
Update codecov CI to stable version of Rust

### DIFF
--- a/.github/workflows/ci_build_test.yml
+++ b/.github/workflows/ci_build_test.yml
@@ -33,7 +33,7 @@ jobs:
           command: build
           args: --verbose --workspace
       - name: Cargo Test
-        run: cargo test --verbose --workspace -- -Z unstable-options
+        run: cargo test --verbose --workspace
       # `clippy-check` will run `cargo clippy` on new pull requests. Due to a limitation in GitHub
       # permissions, the behavior of the Action is different depending on the source of the PR. If the
       # PR comes from the partiql-lang-rust project itself, any suggestions will be added to the PR as comments.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,25 +25,19 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          # Coverage requires the nightly toolchain because it uses the presently unstable `-Z profile` feature
-          # See: https://github.com/rust-lang/rust/issues/42524
-          # See also: https://github.com/actions-rs/grcov#usage
-          # nightly can be very volatile--pin this to a version we know works well...
-          toolchain: nightly-2023-03-09
-      - name: Cargo Test
-        run: cargo test --verbose --workspace
-        env:
-          CARGO_INCREMENTAL: '0'
-          # https://github.com/marketplace/actions/rust-grcov
-          # For some reason the panic=abort modes don't work for build script...
-          #RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          #RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-      - id: coverage
-        name: Code Coverage
-        uses: actions-rs/grcov@v0.1
+          toolchain: stable
+          # We need this component to generate source coverage in stable
+          components: llvm-tools-preview
+      - name: Cargo Install
+        run: cargo install cargo-llvm-cov
+      # Conformance tests are run with 'conformance_test' feature. Since step runs with 'all-features', the conformance
+      # test are also run, which can cause `cargo test` to fail. Add 'continue-on-error' step to prevent GH Actions
+      # failure.
+      - name: Cargo Test w/ Coverage
+        continue-on-error: true
+        run: cargo llvm-cov --verbose --workspace --all-features --no-fail-fast --codecov --output-path codecov.json
       - name: Codecov Upload
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          files: ${{ steps.coverage.outputs.report }}
+          files: codecov.json
+          fail_ci_if_error: true


### PR DESCRIPTION
Similar to https://github.com/partiql/partiql-lang-rust/pull/383. Updates the codecov CI to a stable version of Rust.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
